### PR TITLE
feat: 메인페이지 api 호출

### DIFF
--- a/src/app/MainPage/MainPage.main.CategoryList.Category.Item.jsx
+++ b/src/app/MainPage/MainPage.main.CategoryList.Category.Item.jsx
@@ -1,19 +1,22 @@
 import * as itemS from "./styled/MainPage.main.CategoryList.Category.Item.style"
 
-function Item() {
-    return(
+function Item(props) {
+    return (
         <>
             <itemS.ItemWrapper>
                 <itemS.ItemContainer>
-                <itemS.ItemImg>
-                    <itemS.ItemRecruitContainer>
-                        <itemS.ItemRecruitText type='People'>모집 5명</itemS.ItemRecruitText>
-                        <itemS.ItemRecruitText type='Deadline'>D-3</itemS.ItemRecruitText>
-                    </itemS.ItemRecruitContainer>
-                </itemS.ItemImg>
-                <itemS.ItemName>헤어드라이기</itemS.ItemName>
-                <itemS.ItemPrice>13000원</itemS.ItemPrice>
-            </itemS.ItemContainer>
+                    <itemS.ItemImgContainer>
+                        <itemS.ItemImg src={props.item.imageUrl} />
+                        <itemS.ItemRecruitContainer>
+                            <itemS.ItemRecruitTextContainer>
+                                <itemS.ItemRecruitText type='People'>모집 {props.item.personnel}명</itemS.ItemRecruitText>
+                                <itemS.ItemRecruitText type='Deadline'>D-{props.item.dDay}</itemS.ItemRecruitText>
+                            </itemS.ItemRecruitTextContainer>
+                        </itemS.ItemRecruitContainer>
+                    </itemS.ItemImgContainer>
+                    <itemS.ItemName>{props.item.productName}</itemS.ItemName>
+                    <itemS.ItemPrice>{props.item.price}원</itemS.ItemPrice>
+                </itemS.ItemContainer>
             </itemS.ItemWrapper>
         </>
     )

--- a/src/app/MainPage/MainPage.main.CategoryList.Category.jsx
+++ b/src/app/MainPage/MainPage.main.CategoryList.Category.jsx
@@ -1,12 +1,16 @@
 import * as itemS from "./styled/MainPage.main.CategoryList.Category.style";
 import Item from "./MainPage.main.CategoryList.Category.Item";
+import client from "../../client";
+
 import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from "react";
 
 function Category(props) {
     const navigate = useNavigate();
+    const [items, setItems] = useState();
     let categoryText = '';
 
-    switch(props.category) {
+    switch (props.category) {
         case 'ranking':
             categoryText = '우리 동네 인기 공동구매';
             break;
@@ -17,11 +21,26 @@ function Category(props) {
             categoryText = '나와 가까운 거리의 공동구매';
             break;
         case 'recent-keyword':
-            categoryText = '최근 검색한 ' + props.recentKeyword + ' 공동구매';
+            categoryText = '최근 검색한 상품 공동구매';
             break;
         default:
             categoryText = '';
     }
+
+    useEffect(() => {
+        const auth = import.meta.env.VITE_AUTH;
+        const fetchData = async () => {
+            try {
+                const response = await client(auth).get(
+                    `/posts/${props.category}`
+                );
+                setItems(response.data.result.SimplePostDtoList);
+            } catch (error) {
+                console.error('안된다!!:', error);
+            }
+        };
+        fetchData();
+    }, []);
 
     return (
         <>
@@ -35,9 +54,9 @@ function Category(props) {
                     </itemS.GreaterThanText>
                 </itemS.CategoryTextContainer>
                 <itemS.ItemsContainer>
-                    <Item onClick={() => { navigate('/product'); }} />
-                    <Item />
-                    <Item />
+                    {items && items.map(item=> (
+                        <Item key={item.postId} item={item} onClick={() => { navigate(`/post/${props.category}`); }} />
+                    ))}
                 </itemS.ItemsContainer>
             </itemS.CategoryContainer>
         </>

--- a/src/app/MainPage/styled/MainPage.main.CategoryList.Category.Item.style.js
+++ b/src/app/MainPage/styled/MainPage.main.CategoryList.Category.Item.style.js
@@ -12,22 +12,31 @@ flex-direction: column;
 margin: 12px 5px 0 5px;
 `
 
-export const ItemImg = styled.div`
+export const ItemImg = styled.img`
 width: 100%;
 height: 160px;
-background-color: pink;
 border-radius: 15px;
 `
 
+export const ItemImgContainer = styled.div`
+position: relative;
+`
+
 export const ItemRecruitContainer = styled.div`
-display: flex;
+position: absolute;
+bottom: 0;
+left: 0;
+right: 0;
 height: 32.57px;
 background-color: #212732;
 border-radius: 0 0 15px 15px;
 margin-top: 127.43px;
-justify-content: space-between;
 `
 
+export const ItemRecruitTextContainer = styled.div`
+display: flex;
+justify-content: space-between;
+`
 export const ItemRecruitText = styled.span`
 height: 11px;
 ${(props) =>


### PR DESCRIPTION
<img width="322" alt="image" src="https://github.com/moa-moa-service/moamoa-frontend/assets/81073857/9f227b2a-f41b-44a3-b68c-2af4558364be">

메인 페이지에 각 카테고리별 모집 게시글 조회 api 호출하는 기능 추가했습니다!