### PR TITLE
fix: posts/near api 호출 수정

### DIFF
--- a/src/app/MainPage/MainPage.CategoryDetailPage.Item.jsx
+++ b/src/app/MainPage/MainPage.CategoryDetailPage.Item.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import * as ItemS from './styled/MainPage.CategoryDetailPage.Item.style'
 
-function Item({ product }) { // product 매개변수를 객체로 받음
+function Item({ product }) {
     return(
         <>
             <ItemS.ProductListContainer>
@@ -9,8 +9,8 @@ function Item({ product }) { // product 매개변수를 객체로 받음
                 <ItemS.ProductInfoContainer>
                     <ItemS.ProductInfoText type='title'>{product.productName}</ItemS.ProductInfoText> {/* productName 속성에 접근할 때는 product.productName으로 지정 */}
                     <ItemS.RecruitTextContainer>
-                        <ItemS.ProductInfoText type='people'>모집 인원 | {product.personnel}명</ItemS.ProductInfoText> {/* personnel 속성에 접근할 때는 product.personnel으로 지정 */}
-                        <ItemS.ProductInfoText type='deadline'>모집 마감 | D{product.dDay}</ItemS.ProductInfoText> {/* dDay 속성에 접근할 때는 product.dDay로 지정 */}
+                        <ItemS.ProductInfoText type='people'>상품 수량 | {product.personnel}개</ItemS.ProductInfoText> {/* personnel 속성에 접근할 때는 product.personnel으로 지정 */}
+                        <ItemS.ProductInfoText type='deadline'>모집 마감 | D-{product.dDay}</ItemS.ProductInfoText> {/* dDay 속성에 접근할 때는 product.dDay로 지정 */}
                     </ItemS.RecruitTextContainer>
                     <ItemS.ProductInfoText type='price'>{product.price}원</ItemS.ProductInfoText> {/* price 속성에 접근할 때는 product.price로 지정 */}
                 </ItemS.ProductInfoContainer>

--- a/src/app/MainPage/MainPage.CategoryDetailPage.jsx
+++ b/src/app/MainPage/MainPage.CategoryDetailPage.jsx
@@ -43,8 +43,12 @@ function CategoryDetailPage() {
                 const response = await client(auth).get(
                     `/posts/${category}`
                 );
-                console.log(response.data.result.SimplePostDtoList);
-                setProducts(response.data.result.SimplePostDtoList);
+                if (category === 'near') {
+                    const simplePostDTOs = response.data.result.SimplePostDtoList.map(item => item.simplePostDTO);
+                    setProducts(simplePostDTOs);
+                } else {
+                    setProducts(response.data.result.SimplePostDtoList);
+                }
             } catch (error) {
                 console.error('안된다!!:', error);
             }

--- a/src/app/MainPage/MainPage.main.CategoryList.Category.Item.jsx
+++ b/src/app/MainPage/MainPage.main.CategoryList.Category.Item.jsx
@@ -9,7 +9,7 @@ function Item(props) {
                         <itemS.ItemImg src={props.item.imageUrl} />
                         <itemS.ItemRecruitContainer>
                             <itemS.ItemRecruitTextContainer>
-                                <itemS.ItemRecruitText type='People'>모집 {props.item.personnel}명</itemS.ItemRecruitText>
+                                <itemS.ItemRecruitText type='People'>모집 {props.item.personnel}개</itemS.ItemRecruitText>
                                 <itemS.ItemRecruitText type='Deadline'>D-{props.item.dDay}</itemS.ItemRecruitText>
                             </itemS.ItemRecruitTextContainer>
                         </itemS.ItemRecruitContainer>

--- a/src/app/MainPage/MainPage.main.CategoryList.Category.jsx
+++ b/src/app/MainPage/MainPage.main.CategoryList.Category.jsx
@@ -34,7 +34,14 @@ function Category(props) {
                 const response = await client(auth).get(
                     `/posts/${props.category}`
                 );
-                setItems(response.data.result.SimplePostDtoList);
+                if (props.category === 'near') {
+                    const simplePostDTOs = response.data.result.SimplePostDtoList.map(item => item.simplePostDTO);
+                    setItems(simplePostDTOs);
+                } else {
+                    // console.log(response.data.result.SimplePostDtoList);
+                    setItems(response.data.result.SimplePostDtoList);
+                }
+
             } catch (error) {
                 console.error('안된다!!:', error);
             }

--- a/src/app/RecruitmentPage/Recruitment.main.jsx
+++ b/src/app/RecruitmentPage/Recruitment.main.jsx
@@ -16,7 +16,7 @@ function Recruitment() {
     // const date = new Date(Date.now);
 
     const [formData, setFormData] = useState({
-        'deadline': "2024-02-16T05:51:42.013Z",
+        'deadline': "2024-02-15T00:00:00.000Z",
     });
     const [selectedCategory, setSelectedCategory] = useState();
 
@@ -181,13 +181,13 @@ function Recruitment() {
                             {formData.personnel ? (
                                 <>
                                     <itemS.FilterWrapper style={{ background: "#2B4760" }}>
-                                        <itemS.FilterText style={{ color: "#FFF" }} onClick={() => toggleModal('category')}>{formData.personnel}명</itemS.FilterText>
+                                        <itemS.FilterText style={{ color: "#FFF" }} onClick={() => toggleModal('people')}>{formData.personnel}명</itemS.FilterText>
                                     </itemS.FilterWrapper>
                                 </>
                             ) : (
                                 <>
                                     <itemS.FilterWrapper>
-                                        <itemS.FilterText onClick={() => toggleModal('people')}>모집 인원 선택</itemS.FilterText>
+                                        <itemS.FilterText onClick={() => toggleModal('people')}>상품 수량 선택</itemS.FilterText>
                                     </itemS.FilterWrapper>
                                 </>
                             )}

--- a/src/app/RecruitmentPage/Recruitment.modal.Range.jsx
+++ b/src/app/RecruitmentPage/Recruitment.modal.Range.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 function Range(props) {
     const {onSelectPeople} = props;
-    const [people, setPeople] = useState(1);
+    const [people, setPeople] = useState(0);
 
     const handleChange = (event) => {
         setPeople(event.target.value);
@@ -16,18 +16,18 @@ function Range(props) {
                 e.stopPropagation();
             }}>
                 <itemS.Wrapper>
-                    <itemS.ModalText type='bold'>모집 인원</itemS.ModalText>
+                    <itemS.ModalText type='bold'>상품 수량</itemS.ModalText>
                 </itemS.Wrapper>
                 <itemS.RangeWrapper>
                     <itemS.Range
                         type="range"
-                        min="1"
+                        min="0"
                         max="10"
                         value={people}
                         onChange={handleChange}
                     />
                     <itemS.ModalTextWrapper>
-                        <itemS.ModalText type='bold'>{people}명</itemS.ModalText>
+                        <itemS.ModalText type='bold'>{people}개</itemS.ModalText>
                     </itemS.ModalTextWrapper>
                 </itemS.RangeWrapper>
             </itemS.Background>

--- a/src/app/RecruitmentPage/Recruitment.modal.jsx
+++ b/src/app/RecruitmentPage/Recruitment.modal.jsx
@@ -7,8 +7,7 @@ import React, { useState } from 'react';
 function RecruitmentModal(props) {
     const {onCategory} = props;
     const {onPeople} = props;
-    const initialType = props.data; // 초기값 설정
-    const [isType] = useState(initialType);
+    const [isType] = useState(props.data);
     const [selectedCategory, setSelectedCategory] = useState();
     const [selectedPeople, setSelectedPeople] = useState();
 


### PR DESCRIPTION
<img width="745" alt="image" src="https://github.com/moa-moa-service/moamoa-frontend/assets/81073857/0dc92932-ee2b-472d-9580-d4d396bfecd3">

near 호출 시에만 데이터 타입이 달라 api 호출 후 item 상태에 저장하는 방식 코드 수정했습니다

<img width="150" alt="image" src="https://github.com/moa-moa-service/moamoa-frontend/assets/81073857/886043df-6446-48b7-86d7-4472eef65d51">
<img width="285" alt="image" src="https://github.com/moa-moa-service/moamoa-frontend/assets/81073857/1dfd3e06-6217-484d-adc9-6d38dc427519">
<img width="281" alt="image" src="https://github.com/moa-moa-service/moamoa-frontend/assets/81073857/fbda3e1f-6ac4-472a-9e8e-06bc932c008e">


모집 인원 -> 상품 수량으로 UI에 표시되는 텍스트 수정했습니다