### PR TITLE
feat: 우리 동네 api 호출

### DIFF
--- a/src/app/MyTownPage/MyTownPage.Map.jsx
+++ b/src/app/MyTownPage/MyTownPage.Map.jsx
@@ -1,0 +1,96 @@
+import { Container as MapDiv, NaverMap, Marker, useNavermaps } from 'react-naver-maps';
+import { useState, useEffect, useRef } from 'react';
+
+import client from '../../client';
+import BottomWrapper from './MyTownPage.main.BottomWrapper.jsx';
+
+function Map() {
+    const navermaps = useNavermaps();
+    const mapRef = useRef(null);
+
+    const [isMapLoading, setIsMapLoading] = useState(true);
+    const [myLocation, setMyLocation] = useState({ lat: null, lng: null });
+
+    const [products, setProducts] = useState();
+    const [selectedProduct, setSelectedProduct] = useState();
+
+    const handleMarkerClick = (product) => {
+        setSelectedProduct(product);
+    };
+
+    useEffect(() => {
+        setIsMapLoading(true);
+        if (navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(success, error);
+        }
+        function success(position) {
+            setMyLocation({
+                lat: position.coords.latitude,
+                lng: position.coords.longitude
+            });
+            setIsMapLoading(false);
+        }
+        function error() {
+            console.log('사용자 위치 불러오기 실패');
+            setMyLocation({ lat: 37.4979517, lng: 127.0276188 });
+            setIsMapLoading(false);
+        }
+
+        const auth = import.meta.env.VITE_AUTH;
+        const fetchData = async () => {
+            try {
+                const response = await client(auth).get(
+                    '/posts/near'
+                );
+                setProducts(response.data.result.SimplePostDtoList);
+            } catch (error) {
+                console.error('안된다!!:', error);
+            }
+        };
+        fetchData();
+    }, []);
+
+
+
+    return (
+        <MapDiv style={{
+            width: '100%',
+            height: '80vh',
+        }}>
+            {isMapLoading ? (
+                <div style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    height: '100%',
+                    width: '100%',
+                }}>Loading...</div>
+            ) : (<>
+                <NaverMap
+                    ref={mapRef}
+                    defaultCenter={new navermaps.LatLng(myLocation.lat, myLocation.lng)}
+                    defaultZoom={18}
+                >
+                    {myLocation.lat && myLocation.lng && (
+                        <Marker
+                            position={new navermaps.LatLng(myLocation.lat, myLocation.lng)}
+                        />
+                    )}
+                    {products && products.map(product => (
+                        <Marker
+                            onClick={() => handleMarkerClick(product)}
+                            position={new navermaps.LatLng(product.address.latitude, product.address.longitude)}
+                        />
+                    ))}
+                    {selectedProduct && (
+                    <BottomWrapper product={selectedProduct} />
+                )}
+                </NaverMap>
+            </>
+
+            )}
+        </MapDiv>
+    );
+}
+
+export default Map;

--- a/src/app/MyTownPage/MyTownPage.main.BottomWrapper.jsx
+++ b/src/app/MyTownPage/MyTownPage.main.BottomWrapper.jsx
@@ -1,0 +1,33 @@
+import * as itemRec from '../RecruitmentPage/styled/Recruitment.TradingLocation.style'
+import * as itemS from './styled/MyTownPage.main.style.js'
+
+function BottomWrapper(product) {
+    console.log(product);
+    return (
+        <>
+            <itemRec.BottomWrapper type='town'>
+                <itemS.BottomProductWrapper>
+                    <itemS.ProductImg src={product.product.simplePostDTO.imageUrl}/>
+                    <itemS.ProductTextContainer>
+                        <itemS.ProductTextTop>
+                            <itemS.ProductText type='title'>{product.product.simplePostDTO.productName}</itemS.ProductText>
+                            <itemS.ProductText type='price'>{product.product.simplePostDTO.price}원</itemS.ProductText>
+                        </itemS.ProductTextTop>
+                        <itemS.ProductTextMiddle>
+                            <itemS.ProductText type='place'>행복약국</itemS.ProductText>
+                            <itemS.ProductText type='location'>{product.product.address.name}</itemS.ProductText>
+                        </itemS.ProductTextMiddle>
+                        <itemS.ProductTextBottom>
+                            <itemS.ProductText type='peopleText' style={{ marginRight: '6px' }}>모집인원</itemS.ProductText>
+                            <itemS.ProductText type='people' style={{ marginRight: '18px' }}>{product.product.simplePostDTO.personnel}명</itemS.ProductText>
+                            <itemS.ProductText type='dateText' style={{ marginRight: '6px' }}>모집기간</itemS.ProductText>
+                            <itemS.ProductText type='date'>D-{product.product.simplePostDTO.dDay}</itemS.ProductText>
+                        </itemS.ProductTextBottom>
+                    </itemS.ProductTextContainer>
+                </itemS.BottomProductWrapper>
+            </itemRec.BottomWrapper>
+        </>
+    )
+}
+
+export default BottomWrapper

--- a/src/app/MyTownPage/MyTownPage.main.jsx
+++ b/src/app/MyTownPage/MyTownPage.main.jsx
@@ -1,18 +1,13 @@
 import * as itemRec from '../RecruitmentPage/styled/Recruitment.TradingLocation.style'
-import MyMap from '../RecruitmentPage/Recruitment.MyMap'
+import Map from './MyTownPage.Map.jsx';
 import * as itemS from './styled/MyTownPage.main.style.js'
 
-import { useState, Suspense } from 'react';
+import { Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 
 function MyTown() {
     const navigate = useNavigate();
-    const [response, setResponse] = useState({});
-
-    function handleResponseChange(response) {
-        setResponse(response);
-    }
 
     return (
         <>
@@ -21,35 +16,13 @@ function MyTown() {
                     <itemRec.BackBtn type='town' onClick={() => (navigate(-1))} />
                     <itemS.TopTextContainer>
                         <itemS.TopText>우리 동네 공동 구매 찾기</itemS.TopText>
-                        <itemS.TopText type='bold'>{response.v2?.results[0]?.region?.area3?.name}</itemS.TopText>
+                        <itemS.TopText type='bold'>남가좌동</itemS.TopText>
                     </itemS.TopTextContainer>
                 </itemRec.TopContentContainer>
             </itemRec.TopWrapper>
             <Suspense fallback={null}>
-                <MyMap onResponseChange={handleResponseChange} />
+                <Map/>
             </Suspense>
-            <itemRec.BottomWrapper type='town'>
-                <itemS.BottomProductWrapper>
-                    <itemS.ProductImg/>
-                    <itemS.ProductTextContainer>
-                        <itemS.ProductTextTop>
-                            <itemS.ProductText type='title'>폴로 가디건</itemS.ProductText>
-                            <itemS.ProductText type='price'>60,000원</itemS.ProductText>
-                        </itemS.ProductTextTop>
-                        <itemS.ProductTextMiddle>
-                            
-                            <itemS.ProductText type='place'>행복약국</itemS.ProductText>
-                            <itemS.ProductText type='location'>서울특별시 서대문구 창천동 70-2길 2층</itemS.ProductText>
-                        </itemS.ProductTextMiddle>
-                        <itemS.ProductTextBottom>
-                            <itemS.ProductText type='peopleText' style={{ marginRight: '6px' }}>모집인원</itemS.ProductText>
-                            <itemS.ProductText type='people' style={{ marginRight: '18px' }}>3명</itemS.ProductText>
-                            <itemS.ProductText type='dateText'style={{ marginRight: '6px' }}>모집기간</itemS.ProductText>
-                            <itemS.ProductText type='date'>D-3</itemS.ProductText>
-                        </itemS.ProductTextBottom>
-                    </itemS.ProductTextContainer>
-                </itemS.BottomProductWrapper>
-            </itemRec.BottomWrapper>
         </>
     )
 }

--- a/src/app/MyTownPage/styled/MyTownPage.main.style.js
+++ b/src/app/MyTownPage/styled/MyTownPage.main.style.js
@@ -30,7 +30,7 @@ margin: 25px 20px 25px 20px;
 display: flex;
 `
 
-export const ProductImg = styled.div`
+export const ProductImg = styled.img`
 width: 114px;
 height: 114px;
 border-radius: 15px;

--- a/src/app/RecruitmentPage/Recruitment.MyMap.jsx
+++ b/src/app/RecruitmentPage/Recruitment.MyMap.jsx
@@ -1,7 +1,7 @@
 import { Container as MapDiv, NaverMap, Marker, useNavermaps } from 'react-naver-maps';
 import { useState, useEffect, useRef } from 'react';
 
-function MyMap({ onResponseChange, isTradingLocation, onLocationChange}) {
+function MyMap({ onResponseChange, isTradingLocation, onLocationChange }) {
     const navermaps = useNavermaps();
     const mapRef = useRef(null);
 
@@ -35,7 +35,6 @@ function MyMap({ onResponseChange, isTradingLocation, onLocationChange}) {
     };
 
     useEffect(() => {
-
         if (myLocation.lat !== null && myLocation.lng !== null) {
             onLocationChange(myLocation);
             const geocoder = navermaps.Service.reverseGeocode(
@@ -56,6 +55,10 @@ function MyMap({ onResponseChange, isTradingLocation, onLocationChange}) {
         }
     }, [myLocation.lat, myLocation.lng]);
 
+    const handleDragEnd = () => {
+        handleCenterChanged();
+    };
+
     return (
         <MapDiv style={{
             width: '100%',
@@ -74,7 +77,8 @@ function MyMap({ onResponseChange, isTradingLocation, onLocationChange}) {
                     ref={mapRef}
                     defaultCenter={new navermaps.LatLng(myLocation.lat, myLocation.lng)}
                     defaultZoom={20}
-                    onCenterChanged={isTradingLocation ? handleCenterChanged : undefined}
+                    onDragend={isTradingLocation ? handleDragEnd : undefined}
+                    // 드래그 종료 이벤트 핸들러 추가
                 >
                     {myLocation.lat && myLocation.lng && (
                         <Marker


### PR DESCRIPTION
<img width="304" alt="image" src="https://github.com/moa-moa-service/moamoa-frontend/assets/81073857/0db30982-a28b-42b5-b284-81e66b3e8d16">

우리동네 페이지 클릭 시 보이는 화면

<img width="304" alt="image" src="https://github.com/moa-moa-service/moamoa-frontend/assets/81073857/4ffbe44c-5e8b-4bcc-98b9-1ad8567fc324">
<img width="306" alt="image" src="https://github.com/moa-moa-service/moamoa-frontend/assets/81073857/1ff2fa13-4bb0-4313-875c-dcb498e50629">

마커 클릭 시 바텀에 물품 상세 정보를 담은 창 UI 표시

<img width="890" alt="image" src="https://github.com/moa-moa-service/moamoa-frontend/assets/81073857/43121d4d-2c6c-4c69-b392-3f74a3287f18">
모집하기 > 거래 희망 장소 내에 있는 지도 드래그 시 센터가 변경될 때마다 호출되는 api를 지도 드래그 후 마우스를 놓았을 때의 api 호출하여 마커 표시할 수 있도록 수정